### PR TITLE
Fix `paper-dropdown-menu` label + new property `search-placeholder`

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -235,14 +235,14 @@
                             <paper-item value="orange">Orange</paper-item>
                             <paper-item value="tomato">Tomato</paper-item>
                         </paper-dropdown><br/>
-                        <paper-dropdown multi label="Fruit" name="fruits" min-length="2" error-message="Please select at least 2 fruits">
+                        <paper-dropdown multi label="Fruit" name="fruits_min2" min-length="2" error-message="Please select at least 2 fruits">
                             <paper-item value="apple">Apple</paper-item>
                             <paper-item value="banana">Banana</paper-item>
                             <paper-item value="mango">Mango</paper-item>
                             <paper-item value="orange">Orange</paper-item>
                             <paper-item value="tomato">Tomato</paper-item>
                         </paper-dropdown><br/>
-                        <paper-dropdown multi label="Fruit" name="fruits" min-length="2" max-length="4" error-message="You can select 2-4 fruits">
+                        <paper-dropdown multi label="Fruit" name="fruits_min2_max2" min-length="2" max-length="4" error-message="You can select 2-4 fruits">
                             <paper-item value="apple">Apple</paper-item>
                             <paper-item value="banana">Banana</paper-item>
                             <paper-item value="mango">Mango</paper-item>
@@ -252,6 +252,17 @@
                         <button type="submit">Submit</button>
                     </form>
                 </iron-form>
+                <script>
+                    (function() {
+                        var form = document.getElementById('form1');
+                        form.addEventListener('submit', function() {
+                            var valid = form.validate();
+                            if (valid) {
+                                console.log(form.serializeForm());
+                            }
+                        });
+                    })()
+                </script>
             </template>
         </demo-snippet>
     </div>

--- a/paper-dropdown.html
+++ b/paper-dropdown.html
@@ -90,7 +90,7 @@
                         bind-value="{{_searchText}}">
                         <input
                             id="search-box"
-                            placeholder="Search..."
+                            placeholder="[[searchPlaceholder]]"
                             type="text"
                             on-tap="_stopEventPropagation"
                             on-keydown="_stopEventPropagation"
@@ -313,6 +313,7 @@
                     value: false,
                     observer: '_multiChanged'
                 },
+
                 /**
                  * Can be used to use a different language when displaying
                  * that more than one item is selected. 
@@ -321,6 +322,15 @@
                 multiLabel: {
                     type: String,
                     value: 'items selected'
+                },
+
+                /**
+                 * Placeholder text for the search input. Only visible if
+                 * `searchable` is `true`.
+                 */
+                searchPlaceholder: {
+                    type: String,
+                    value: 'Search...'
                 }
             },
             observers: [

--- a/paper-dropdown.html
+++ b/paper-dropdown.html
@@ -430,11 +430,11 @@
             _updateSelectedItemLabel: function(label) {
                 if (this.multi) {
                     if (this._selectedItems.length > 1) {
-                        this.$.dropdownMenu._setSelectedItemLabel(this._selectedItems.length + ' ' + this.multiLabel);
+                        this.$.dropdownMenu.value = this._selectedItems.length + ' ' + this.multiLabel;
                     } else if (this._selectedItems.length == 1) {
-                        this.$.dropdownMenu._setSelectedItemLabel(this._selectedItems[0].textContent.trim());
+                        this.$.dropdownMenu.value = this._selectedItems[0].textContent.trim();
                     } else {
-                        this.$.dropdownMenu._setSelectedItemLabel(null);
+                        this.$.dropdownMenu.value = null;
                     }
                 }
             },


### PR DESCRIPTION
* Updating the `selected-item-label` on the `paper-dropdown-menu` element doesn't change the `paper-input` anymore since v2.0.3 - see https://github.com/PolymerElements/paper-dropdown-menu/commit/a13f011fb3680422d54d3790021e31906268194a

* added a new property `search-placeholder` e.g. for using another language